### PR TITLE
Return null to JS when the result set has a null in it!

### DIFF
--- a/src/edge-sql/EdgeCompiler.cs
+++ b/src/edge-sql/EdgeCompiler.cs
@@ -74,9 +74,13 @@ public class EdgeCompiler
                         object[] resultRecord = new object[record.FieldCount];
                         record.GetValues(resultRecord);
                         for (int i = 0; i < record.FieldCount; i++)
-                        {
+                        {      
                             Type type = record.GetFieldType(i);
-                            if (type == typeof(byte[]) || type == typeof(char[]))
+                            if (resultRecord[i] is System.DBNull)
+                            {
+                                resultRecord[i] = null;
+                            }
+                            else if (type == typeof(byte[]) || type == typeof(char[]))
                             {
                                 resultRecord[i] = Convert.ToBase64String((byte[])resultRecord[i]);
                             }


### PR DESCRIPTION
I'm not sure how you do your releases, so here is just like the C# or something!

The current npm module will return an empty object in place of arrays at present! This makes it return an actual null.
