### PR TITLE
path.join avoids hardcoding platform dir separator

### DIFF
--- a/lib/edge-sql.js
+++ b/lib/edge-sql.js
@@ -1,3 +1,3 @@
 exports.getCompiler = function () {
-	return process.env.EDGE_SQL_NATIVE || (__dirname + '\\edge-sql.dll');
+	return process.env.EDGE_SQL_NATIVE || (require('path').join(__dirname, 'edge-sql.dll'));
 };


### PR DESCRIPTION
Using [path.join](http://nodejs.org/api/path.html#path_path_join_path1_path2) prevents hard-coding platform-specific path separator (hard-coded right now as backslash that's only good on Windows).
