### PR TITLE
Add support for passing the SqlCommand.CommandTimeout property

### DIFF
--- a/src/edge-sql/EdgeCompiler.cs
+++ b/src/edge-sql/EdgeCompiler.cs
@@ -11,17 +11,23 @@ public class EdgeCompiler
     {
         string command = ((string)parameters["source"]).TrimStart();
         string connectionString = Environment.GetEnvironmentVariable("EDGE_SQL_CONNECTION_STRING");
+        int timeout = 30;
         object tmp;
         if (parameters.TryGetValue("connectionString", out tmp))
         {
             connectionString = (string)tmp;
         }
 
+        if (parameters.TryGetValue("timeout", out tmp))
+        {
+            timeout = (int)tmp;
+        }
+
         if (command.StartsWith("select ", StringComparison.InvariantCultureIgnoreCase))
         {
             return async (queryParameters) =>
             {
-                return await this.ExecuteQuery(connectionString, command, (IDictionary<string, object>)queryParameters);
+                return await this.ExecuteQuery(connectionString, command, timeout, (IDictionary<string, object>)queryParameters);
             };
         }
         else if (command.StartsWith("insert ", StringComparison.InvariantCultureIgnoreCase)
@@ -30,7 +36,7 @@ public class EdgeCompiler
         {
             return async (queryParameters) =>
             {
-                return await this.ExecuteNonQuery(connectionString, command, (IDictionary<string, object>)queryParameters);
+                return await this.ExecuteNonQuery(connectionString, command, timeout, (IDictionary<string, object>)queryParameters);
             };
         }
         else if (command.StartsWith("exec ", StringComparison.InvariantCultureIgnoreCase))
@@ -39,6 +45,7 @@ public class EdgeCompiler
                 this.ExecuteStoredProcedure(
                     connectionString,
                     command,
+                    timeout,
                     (IDictionary<string, object>)queryParameters);
         }
         else
@@ -47,8 +54,10 @@ public class EdgeCompiler
         }
     }
 
-    void AddParamaters(SqlCommand command, IDictionary<string, object> parameters)
+    void AddParamaters(SqlCommand command, IDictionary<string, object> parameters, int timeout)
     {
+        command.CommandTimeout = timeout;
+
         if (parameters != null)
         {
             foreach (KeyValuePair<string, object> parameter in parameters)
@@ -58,21 +67,21 @@ public class EdgeCompiler
         }
     }
 
-    async Task<object> ExecuteQuery(string connectionString, string commandString, IDictionary<string, object> parameters)
+    async Task<object> ExecuteQuery(string connectionString, string commandString, int timeout, IDictionary<string, object> parameters)
     {
         using (SqlConnection connection = new SqlConnection(connectionString))
         {
             using (var command = new SqlCommand(commandString, connection))
             {
-                return await this.ExecuteQuery(parameters, command, connection);
+                return await this.ExecuteQuery(parameters, timeout, command, connection);
             }
         }
     }
 
-    async Task<object> ExecuteQuery(IDictionary<string, object> parameters, SqlCommand command, SqlConnection connection)
+    async Task<object> ExecuteQuery(IDictionary<string, object> parameters, int timeout, SqlCommand command, SqlConnection connection)
     {
         List<object> rows = new List<object>();
-        this.AddParamaters(command, parameters);
+        this.AddParamaters(command, parameters, timeout);
         await connection.OpenAsync();
         using (SqlDataReader reader = await command.ExecuteReaderAsync(CommandBehavior.CloseConnection))
         {
@@ -84,7 +93,7 @@ public class EdgeCompiler
                 record.GetValues(resultRecord);
 
                 for (int i = 0; i < record.FieldCount; i++)
-                {      
+                {
                     Type type = record.GetFieldType(i);
                     if (resultRecord[i] is System.DBNull)
                     {
@@ -113,13 +122,13 @@ public class EdgeCompiler
         }
     }
 
-    async Task<object> ExecuteNonQuery(string connectionString, string commandString, IDictionary<string, object> parameters)
+    async Task<object> ExecuteNonQuery(string connectionString, string commandString, int timeout, IDictionary<string, object> parameters)
     {
         using (var connection = new SqlConnection(connectionString))
         {
             using (var command = new SqlCommand(commandString, connection))
             {
-                this.AddParamaters(command, parameters);
+                this.AddParamaters(command, parameters, timeout);
                 await connection.OpenAsync();
                 return await command.ExecuteNonQueryAsync();
             }
@@ -129,6 +138,7 @@ public class EdgeCompiler
     async Task<object> ExecuteStoredProcedure(
         string connectionString,
         string commandString,
+        int timeout,
         IDictionary<string, object> parameters)
     {
         using (SqlConnection connection = new SqlConnection(connectionString))
@@ -139,7 +149,7 @@ public class EdgeCompiler
             };
             using (command)
             {
-                return await this.ExecuteQuery(parameters, command, connection);
+                return await this.ExecuteQuery(parameters, timeout, command, connection);
             }
         }
     }


### PR DESCRIPTION
- Timeout defaults to 30 seconds - http://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlcommand.commandtimeout%28v=vs.110%29.aspx

In reference to issue: https://github.com/tjanczuk/edge/issues/211

Note: Hilariously, I didn't notice [this pull request from @Miramac](https://github.com/tjanczuk/edge-sql/pull/10) before I did this. Feel free to ignore. I just want make sure this feature request isn't completely forgotten. :wink:
